### PR TITLE
Eslint Configuration Changes

### DIFF
--- a/style/javascript/.eslintrc.json
+++ b/style/javascript/.eslintrc.json
@@ -5,5 +5,6 @@
     "React": false
   },
   "rules": {
+    "space-before-function-paren": ["error", {"named": "never", "anonymous": "never"}],
   }
 }

--- a/style/javascript/.eslintrc.json
+++ b/style/javascript/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+  "plugins": ["react"],
   "parser": "babel-eslint",
   "extends": ["standard"],
   "globals": {
@@ -14,5 +15,6 @@
       "imports": "always-multiline",
       "exports": "always-multiline"
     }],
+    "react/jsx-uses-vars": "error"
   }
 }

--- a/style/javascript/.eslintrc.json
+++ b/style/javascript/.eslintrc.json
@@ -1,6 +1,9 @@
 {
   "parser": "babel-eslint",
   "extends": ["standard"],
+  "globals": {
+    "React": false
+  },
   "rules": {
   }
 }

--- a/style/javascript/.eslintrc.json
+++ b/style/javascript/.eslintrc.json
@@ -1,3 +1,6 @@
 {
-  "extends": ["standard"]
+  "parser": "babel-eslint",
+  "extends": ["standard"],
+  "rules": {
+  }
 }

--- a/style/javascript/.eslintrc.json
+++ b/style/javascript/.eslintrc.json
@@ -6,5 +6,7 @@
   },
   "rules": {
     "space-before-function-paren": ["error", {"named": "never", "anonymous": "never"}],
+    "quotes": ["error", "double"],
+    "jsx-quotes": ["error", "prefer-double"],
   }
 }

--- a/style/javascript/.eslintrc.json
+++ b/style/javascript/.eslintrc.json
@@ -8,5 +8,11 @@
     "space-before-function-paren": ["error", {"named": "never", "anonymous": "never"}],
     "quotes": ["error", "double"],
     "jsx-quotes": ["error", "prefer-double"],
+    "comma-dangle": ["error", {
+      "arrays": "always-multiline",
+      "objects": "always-multiline",
+      "imports": "always-multiline",
+      "exports": "always-multiline"
+    }],
   }
 }


### PR DESCRIPTION
This changes a few rules:

* Prefer double quotes over single quotes.  I changed this, because that is the preference on the Ruby side, and it will help developers who are jumping back and forth from JS to Ruby.  Like me 😬 
* Prefer comma dangle when you have multiline objects, arrays, imports, exports
  ```js
  // Prefer this
  const myObject = {
    foo: 1,
    bar: 2,
  }
  // Over this
  const myObject = {
    foo: 1,
    bar: 2
  }
  ```
  This makes it easier to add and remove items from the object without muddying up the diff
* Prefer no space before function parens
  ```js
  // Prefer this
  class MyComponent extends Component {
    render() { null }
  }
  // Over this
  class MyComponent extends Component {
    render () { null }
  }
  ```