### PR TITLE
[FE] empty before line

### DIFF
--- a/style/sass/.stylelintrc.json
+++ b/style/sass/.stylelintrc.json
@@ -41,6 +41,7 @@
     ],
     "block-opening-brace-space-before": "always",
     "declaration-block-semicolon-newline-before": "never-multi-line",
+    "rule-empty-line-before": "always",
     "length-zero-no-unit": true,
     "number-leading-zero": "always",
     "scss/operator-no-unspaced": true


### PR DESCRIPTION
This makes styles easier to read.

Reference: https://github.com/stylelint/stylelint/blob/master/lib/rules/rule-empty-line-before/README.md

![image](https://user-images.githubusercontent.com/10679537/38279369-f7e54cba-376d-11e8-869a-7384ac000d94.png)
