### PR TITLE
Update stylelint config

### DIFF
--- a/style/sass/.stylelintrc.json
+++ b/style/sass/.stylelintrc.json
@@ -15,7 +15,6 @@
       {
         "type": "at-rule",
         "name": "include",
-        "parameter": "mq",
         "hasBlock": true
       },
       {


### PR DESCRIPTION
Remove parameter so that any include that has a block gets
placed beneath the main declaration and not at the top of it.