### PR TITLE
Enforce use of react prop-types and do not allow console.log

### DIFF
--- a/style/javascript/.eslintrc.json
+++ b/style/javascript/.eslintrc.json
@@ -27,6 +27,7 @@
       }
     ],
     "prefer-const": ["error"],
-    "react/jsx-uses-vars": "error"
+    "react/jsx-uses-vars": "error",
+    "react/prop-types": [1, { "ignore": ["children", "className", "render"] }]
   }
 }

--- a/style/javascript/.eslintrc.json
+++ b/style/javascript/.eslintrc.json
@@ -3,6 +3,11 @@
     "browser": true
   },
   "plugins": ["react"],
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  },
   "parser": "babel-eslint",
   "extends": ["standard"],
   "globals": {
@@ -26,6 +31,7 @@
         "exports": "always-multiline"
       }
     ],
+    "no-console": ["error", { "allow": ["warn", "error"] }],
     "prefer-const": ["error"],
     "react/jsx-uses-vars": "error",
     "react/prop-types": [1, { "ignore": ["children", "className", "render"] }]


### PR DESCRIPTION
- Make sure that react prop-types are included in the app. PropTypes are great for type checking and as documentation for what to expect in props.
 - Console.log should not be used in production. Make sure it is removed.